### PR TITLE
Speed up with lazy loading and webpack optimizations

### DIFF
--- a/src/containers/Summary/Sidebar.jsx
+++ b/src/containers/Summary/Sidebar.jsx
@@ -7,8 +7,6 @@ import InfoIcon from '@material-ui/icons/Info';
 import Divider from '@material-ui/core/Divider';
 import { Clear } from '@material-ui/icons';
 import IconButton from '@material-ui/core/IconButton';
-import nitrateTrendStationsData20Years from '../../data/nitrate_trend_station_data_20years.json';
-import phosTrendStationData20Years from '../../data/phos_trend_station_data_20years.json';
 import NoSignificantTrendIcon from '../../images/No_Significant_Trend_Icon.png';
 import UpwardTrendIcon from '../../images/Upward_Trending_Icon.png';
 import DownwardTrendIcon from '../../images/Downward_Trending_Icon.png';
@@ -179,7 +177,7 @@ function convertTrend(inputString) {
 }
 
 
-const Sidebar = ({ stationData, selectedNutrient,setSelectedNutrient,selectedTimePeriod,setSelectedTimePeriod, removeSelectedStation }) => {
+const Sidebar = ({ stationData, selectedNutrient,setSelectedNutrient,selectedTimePeriod,setSelectedTimePeriod, removeSelectedStation, nitrateTrendStationsData20Years, phosTrendStationData20Years }) => {
     const classes = useStyles();
     const [data,setData] = React.useState(null);
     const [openInfoDialog, setOpenInfoDialog] = React.useState(false);

--- a/src/containers/Summary/Sidebar.jsx
+++ b/src/containers/Summary/Sidebar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, FormControl, FormLabel, InputBase, Select, MenuItem, Typography, Dialog, DialogTitle, DialogContent,
+import { Box, FormControl, FormLabel, Select, MenuItem, Typography, Dialog, DialogTitle, DialogContent,
     DialogContentText, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper }from '@material-ui/core';
 import Tooltip from '@material-ui/core/Tooltip';
 import InfoIcon from '@material-ui/icons/Info';
@@ -11,6 +11,8 @@ import NoSignificantTrendIcon from '../../images/No_Significant_Trend_Icon.png';
 import UpwardTrendIcon from '../../images/Upward_Trending_Icon.png';
 import DownwardTrendIcon from '../../images/Downward_Trending_Icon.png';
 
+import phosTrendStationDataUrl from '../../data/phos_trend_station_data_20years.json';
+import nitrateTrendStationsDataUrl from '../../data/nitrate_trend_station_data_20years.json';
 
 
 import SummaryGraph from './SummaryGraph';
@@ -176,11 +178,25 @@ function convertTrend(inputString) {
     return conversionDict[inputString];
 }
 
-
-const Sidebar = ({ stationData, selectedNutrient,setSelectedNutrient,selectedTimePeriod,setSelectedTimePeriod, removeSelectedStation, nitrateTrendStationsData20Years, phosTrendStationData20Years }) => {
+const Sidebar = ({ stationData, selectedNutrient,setSelectedNutrient,selectedTimePeriod,setSelectedTimePeriod, removeSelectedStation }) => {
     const classes = useStyles();
-    const [data,setData] = React.useState(null);
+    const [data, setData] = React.useState(null);
     const [openInfoDialog, setOpenInfoDialog] = React.useState(false);
+    const [nitrateTrendStationsData20Years, setNitrateTrendStationsData20Years] = React.useState(null);
+    const [phosTrendStationData20Years, setPhosTrendStationData20Years] = React.useState(null);
+
+    React.useEffect(() => {
+        fetch(nitrateTrendStationsDataUrl)
+            .then(response => response.json())
+            .then(nitrateData => {
+                setNitrateTrendStationsData20Years(nitrateData);
+            });
+        fetch(phosTrendStationDataUrl)
+            .then(response => response.json())
+            .then(phosData => {
+                setPhosTrendStationData20Years(phosData);
+            });
+    }, []);
 
     React.useEffect(() => {
         if (stationData) {
@@ -195,7 +211,7 @@ const Sidebar = ({ stationData, selectedNutrient,setSelectedNutrient,selectedTim
         } else {
             setData(null);
         }
-    }, [stationData]);
+    }, [stationData,nitrateTrendStationsData20Years, phosTrendStationData20Years]);
 
     // Remove the selected station when the time period is changed
     React.useEffect(() => {

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -198,10 +198,12 @@ const Summary = () => {
     const [tooltipPosition, setTooltipPosition] = React.useState({ x: 0, y: 0 });
     const tooltipRef = React.useRef();
 
-    // Lazy load the geoJSON files
+    // Lazy load the geoJSON and json files
     const [nitrateTrendStationsLayer20years, setNitrateTrendStationsLayer20years] = React.useState(null);
     const [phosTrendStationsLayer20years, setPhosTrendStationsLayer20years] = React.useState(null);
     const [waterShedsLayer20years, setWaterShedsLayer20years] = React.useState(null);
+    const [nitrateTrendStationsData20Years, setNitrateTrendStationsData20Years] = React.useState(null)
+    const [phosTrendStationData20Years, setPhosTrendStationData20Years] = React.useState(null)
 
     // useEffect to lazy load the geoJSON files
     React.useEffect(()=>{
@@ -264,6 +266,8 @@ const Summary = () => {
                 })
             );
         });
+        import ("../../data/phos_trend_station_data_20years.json").then((data)=>setPhosTrendStationData20Years(data.default))
+        import ("../../data/nitrate_trend_station_data_20years.json").then((data)=>setNitrateTrendStationsData20Years(data.default))
     },[]);
 
     
@@ -526,7 +530,9 @@ const Summary = () => {
         setSelectedWatershed(null);
     };
 
-    if (nitrateTrendStationsLayer20years === null || phosTrendStationsLayer20years === null || waterShedsLayer20years === null) return <div>Loading...</div>;
+    if (nitrateTrendStationsLayer20years === null || phosTrendStationsLayer20years === null ||
+      waterShedsLayer20years === null || nitrateTrendStationsData20Years === null ||
+      phosTrendStationData20Years === null) return <div>Loading...</div>;
 
 
     return (
@@ -593,6 +599,8 @@ const Summary = () => {
                         selectedTimePeriod={selectedTimePeriod}
                         setSelectedTimePeriod={setSelectedTimePeriod}
                         removeSelectedStation={removeSelectedStation}
+                        nitrateTrendStationsData20Years={nitrateTrendStationsData20Years}
+                        phosTrendStationData20Years={phosTrendStationData20Years}
                     />
                 </Grid>
             </Grid>

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -208,10 +208,9 @@ const Summary = () => {
     const [phosTrendStationData20Years, setPhosTrendStationData20Years] = React.useState(null);
 
     const makeLayerVisible = () =>{
-        const map: MapType = mapRef.current;
+        const map= mapRef.current;
         if (map) {
             map.getLayers().forEach((layer) => {
-                console.log('Layer title', layer.get('title'));
                 if (layer.get('title').startsWith('Nitrate'))
                     layer.setVisible(selectedNutrient === 'Nitrogen');
                 if (layer.get('title').startsWith('Phosphorus'))

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -204,8 +204,8 @@ const Summary = () => {
     const [nitrateTrendStationsLayer20years, setNitrateTrendStationsLayer20years] = React.useState(null);
     const [phosTrendStationsLayer20years, setPhosTrendStationsLayer20years] = React.useState(null);
     const [waterShedsLayer20years, setWaterShedsLayer20years] = React.useState(null);
-    const [nitrateTrendStationsData20Years, setNitrateTrendStationsData20Years] = React.useState(null)
-    const [phosTrendStationData20Years, setPhosTrendStationData20Years] = React.useState(null)
+    const [nitrateTrendStationsData20Years, setNitrateTrendStationsData20Years] = React.useState(null);
+    const [phosTrendStationData20Years, setPhosTrendStationData20Years] = React.useState(null);
 
     // useEffect to lazy load the geoJSON files
     React.useEffect(()=>{
@@ -236,7 +236,7 @@ const Summary = () => {
                     title: 'Phosphorus Trend Stations',
                     layers: [
                         new VectorLayer({
-                            visible: true,
+                            visible: false,
                             title: 'Trend Stations',
                             source: new VectorSource({
                                 url: phosTrendStationsJSON20Years,
@@ -268,8 +268,8 @@ const Summary = () => {
                 })
             );
         });
-        import ("../../data/phos_trend_station_data_20years.json").then((data)=>setPhosTrendStationData20Years(data.default))
-        import ("../../data/nitrate_trend_station_data_20years.json").then((data)=>setNitrateTrendStationsData20Years(data.default))
+        import ('../../data/phos_trend_station_data_20years.json').then((data)=>setPhosTrendStationData20Years(data.default));
+        import ('../../data/nitrate_trend_station_data_20years.json').then((data)=>setNitrateTrendStationsData20Years(data.default));
     },[]);
 
     
@@ -536,12 +536,12 @@ const Summary = () => {
       waterShedsLayer20years === null || nitrateTrendStationsData20Years === null ||
       phosTrendStationData20Years === null){
         return (
-          <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-              <Box textAlign="center">
-                  <CircularProgress />
-                  <p>Loading data...</p>
-              </Box>
-          </Box>
+            <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+                <Box textAlign="center">
+                    <CircularProgress />
+                    <p>Loading data...</p>
+                </Box>
+            </Box>
         );
     }
 

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -236,7 +236,7 @@ const Summary = () => {
                     title: 'Phosphorus Trend Stations',
                     layers: [
                         new VectorLayer({
-                            visible: false,
+                            visible: true,
                             title: 'Trend Stations',
                             source: new VectorSource({
                                 url: phosTrendStationsJSON20Years,
@@ -504,7 +504,7 @@ const Summary = () => {
                     layer.setVisible(selectedNutrient === 'Phosphorus');
             });
         }
-    }, [selectedNutrient]);
+    }, [selectedNutrient, phosTrendStationsLayer20years, nitrateTrendStationsData20Years]);
 
     const handleMapHover = (event) => {
         const pixel = event.pixel;

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Box from '@material-ui/core/Box';
 import TileLayer from 'ol/layer/Tile';
 import GroupLayer from 'ol/layer/Group';
 import XYZ from 'ol/source/XYZ';
@@ -532,7 +534,16 @@ const Summary = () => {
 
     if (nitrateTrendStationsLayer20years === null || phosTrendStationsLayer20years === null ||
       waterShedsLayer20years === null || nitrateTrendStationsData20Years === null ||
-      phosTrendStationData20Years === null) return <div>Loading...</div>;
+      phosTrendStationData20Years === null){
+        return (
+          <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+              <Box textAlign="center">
+                  <CircularProgress />
+                  <p>Loading data...</p>
+              </Box>
+          </Box>
+        );
+    }
 
 
     return (

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -21,9 +21,7 @@ import HighDownwardTrendIcon from '../../images/Downward_Trending_Icon.png';
 
 import MapLegendIcon from '../../images/Map_Legend_Icon.png';
 import { GEOSERVER_URL, MAP_BOUNDS } from './config';
-import nitrateTrendStationsJSON20Years from '../../data/nitrate_trend_stations_20_years.geojson';
-import phosTrendStationsJSON20Years from '../../data/phos_trend_stations_20_years.geojson';
-import waterShedsJSON20years from '../../data/watersheds_20years.geojson';
+
 import Sidebar from './Sidebar';
 
 // Styling for different components of Nutrient Trends Dashboard
@@ -200,6 +198,76 @@ const Summary = () => {
     const [tooltipPosition, setTooltipPosition] = React.useState({ x: 0, y: 0 });
     const tooltipRef = React.useRef();
 
+    // Lazy load the geoJSON files
+    const [nitrateTrendStationsLayer20years, setNitrateTrendStationsLayer20years] = React.useState(null);
+    const [phosTrendStationsLayer20years, setPhosTrendStationsLayer20years] = React.useState(null);
+    const [waterShedsLayer20years, setWaterShedsLayer20years] = React.useState(null);
+
+    // useEffect to lazy load the geoJSON files
+    React.useEffect(()=>{
+        import('../../data/nitrate_trend_stations_20_years.geojson').then((data) => {
+            const nitrateTrendStationsJSON20Years = data.default;
+            setNitrateTrendStationsLayer20years(
+                new GroupLayer({
+                    title: 'Nitrate Trend Stations',
+                    layers: [
+                        new VectorLayer({
+                            visible: true,
+                            title: 'Trend Stations',
+                            source: new VectorSource({
+                                url: nitrateTrendStationsJSON20Years,
+                                format: new GeoJSON()
+                            }),
+                            interactive: true,
+                            style: renderIcon
+                        })
+                    ]
+                })
+            );
+        });
+        import('../../data/phos_trend_stations_20_years.geojson').then((data) => {
+            const phosTrendStationsJSON20Years = data.default;
+            setPhosTrendStationsLayer20years(
+                new GroupLayer({
+                    title: 'Phosphorus Trend Stations',
+                    layers: [
+                        new VectorLayer({
+                            visible: true,
+                            title: 'Trend Stations',
+                            source: new VectorSource({
+                                url: phosTrendStationsJSON20Years,
+                                format: new GeoJSON()
+                            }),
+                            interactive: true,
+                            style: renderIcon
+                        })
+                    ] })
+            );
+        });
+        import ('../../data/watersheds_20years.geojson').then((data) => {
+            const waterShedsJSON20years = data.default;
+            setWaterShedsLayer20years(
+                new GroupLayer({
+                    title: 'Watershed Layer',
+                    layers: [
+                        new VectorLayer({
+                            visible: true,
+                            title: 'Watersheds',
+                            source: new VectorSource({
+                                url: waterShedsJSON20years,
+                                format: new GeoJSON()
+                            }),
+                            interactive: true,
+                            style: renderWaterSheds
+                        })
+                    ]
+                })
+            );
+        });
+    },[]);
+
+    
+
     // This group layer contains the base map and the state boundaries layer
     const basemaps = new GroupLayer({
         title: 'Base Maps',
@@ -233,53 +301,6 @@ const Summary = () => {
         ]
     });
 
-    const nitrateTrendStationsLayer20years = new GroupLayer({
-        title: 'Nitrate Trend Stations',
-        layers: [
-            new VectorLayer({
-                visible: true,
-                title: 'Trend Stations',
-                source: new VectorSource({
-                    url: nitrateTrendStationsJSON20Years,
-                    format: new GeoJSON()
-                }),
-                interactive: true,
-                style: renderIcon
-            })
-        ]
-    });
-
-    const phosTrendStationsLayer20years = new GroupLayer({
-        title: 'Phosphorus Trend Stations',
-        layers: [
-            new VectorLayer({
-                visible: true,
-                title: 'Trend Stations',
-                source: new VectorSource({
-                    url: phosTrendStationsJSON20Years,
-                    format: new GeoJSON()
-                }),
-                interactive: true,
-                style: renderIcon
-            })
-        ]
-    });
-
-    const waterShedsLayer20years = new GroupLayer({
-        title: 'Watershed Layer',
-        layers: [
-            new VectorLayer({
-                visible: true,
-                title: 'Watersheds',
-                source: new VectorSource({
-                    url: waterShedsJSON20years,
-                    format: new GeoJSON()
-                }),
-                interactive: true,
-                style: renderWaterSheds
-            })
-        ]
-    });
 
     const riversLayer = new GroupLayer({
         title: 'Rivers',
@@ -504,6 +525,9 @@ const Summary = () => {
         setSelectedStation(null);
         setSelectedWatershed(null);
     };
+
+    if (nitrateTrendStationsLayer20years === null || phosTrendStationsLayer20years === null || waterShedsLayer20years === null) return <div>Loading...</div>;
+
 
     return (
         <>

--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -207,6 +207,19 @@ const Summary = () => {
     const [nitrateTrendStationsData20Years, setNitrateTrendStationsData20Years] = React.useState(null);
     const [phosTrendStationData20Years, setPhosTrendStationData20Years] = React.useState(null);
 
+    const makeLayerVisible = () =>{
+        const map: MapType = mapRef.current;
+        if (map) {
+            map.getLayers().forEach((layer) => {
+                console.log('Layer title', layer.get('title'));
+                if (layer.get('title').startsWith('Nitrate'))
+                    layer.setVisible(selectedNutrient === 'Nitrogen');
+                if (layer.get('title').startsWith('Phosphorus'))
+                    layer.setVisible(selectedNutrient === 'Phosphorus');
+            });
+        }
+    };
+    
     // useEffect to lazy load the geoJSON files
     React.useEffect(()=>{
         import('../../data/nitrate_trend_stations_20_years.geojson').then((data) => {
@@ -268,8 +281,14 @@ const Summary = () => {
                 })
             );
         });
-        import ('../../data/phos_trend_station_data_20years.json').then((data)=>setPhosTrendStationData20Years(data.default));
-        import ('../../data/nitrate_trend_station_data_20years.json').then((data)=>setNitrateTrendStationsData20Years(data.default));
+        import ('../../data/phos_trend_station_data_20years.json').then((data)=>{
+            const phosData = data.default;
+            setPhosTrendStationData20Years(phosData);
+        });
+        import ('../../data/nitrate_trend_station_data_20years.json').then((data)=>{
+            const nitrateData = data.default;
+            setNitrateTrendStationsData20Years(nitrateData);
+        });
     },[]);
 
     
@@ -494,16 +513,7 @@ const Summary = () => {
         setSelectedWatershed(null);
 
         // Change the visibility of the layers ccording to the nutrient
-
-        const map: MapType = mapRef.current;
-        if (map) {
-            map.getLayers().forEach((layer) => {
-                if (layer.get('title').startsWith('Nitrate'))
-                    layer.setVisible(selectedNutrient === 'Nitrogen');
-                if (layer.get('title').startsWith('Phosphorus'))
-                    layer.setVisible(selectedNutrient === 'Phosphorus');
-            });
-        }
+        makeLayerVisible();
     }, [selectedNutrient, phosTrendStationsLayer20years, nitrateTrendStationsData20Years]);
 
     const handleMapHover = (event) => {
@@ -527,6 +537,7 @@ const Summary = () => {
         phosTrendStationsLayer20years
     };
 
+    makeLayerVisible();
     const removeSelectedStation = () => {
         setSelectedStation(null);
         setSelectedWatershed(null);
@@ -610,8 +621,6 @@ const Summary = () => {
                         selectedTimePeriod={selectedTimePeriod}
                         setSelectedTimePeriod={setSelectedTimePeriod}
                         removeSelectedStation={removeSelectedStation}
-                        nitrateTrendStationsData20Years={nitrateTrendStationsData20Years}
-                        phosTrendStationData20Years={phosTrendStationData20Years}
                     />
                 </Grid>
             </Grid>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,6 +27,11 @@ module.exports = {
         filename: 'js/[name]-[chunkhash].js',
         crossOriginLoading: 'anonymous'
     },
+    optimization: {
+        splitChunks: {
+            chunks: 'all'
+        }
+    },
 
     module: {
         rules: [
@@ -37,6 +42,7 @@ module.exports = {
                     {
                         loader: 'babel-loader',
                         options: {
+                            cacheDirectory: true,
                             presets: [
                                 '@babel/env',
                                 '@babel/flow',
@@ -166,7 +172,7 @@ module.exports = {
         }),
         new Webpack.DefinePlugin({
             'process.env.VERSION': JSON.stringify(
-                dependencies['@geostreams/core']
+              dependencies['@geostreams/core']
             ),
             'process.env.CONTEXT': JSON.stringify(process.env.CONTEXT)
         }),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,6 +27,7 @@ module.exports = {
         filename: 'js/[name]-[chunkhash].js',
         crossOriginLoading: 'anonymous'
     },
+
     optimization: {
         splitChunks: {
             chunks: 'all'
@@ -120,6 +121,19 @@ module.exports = {
                     }
                 ]
             },
+            // loader for specific json files
+            {
+                type: 'javascript/auto',
+                test: /data_20years\.json$/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: 'files/[name]-[contenthash].[ext]'
+                        }
+                    }
+                ]  
+            },
             {
                 test: /\.svg$/,
                 use: [
@@ -172,7 +186,7 @@ module.exports = {
         }),
         new Webpack.DefinePlugin({
             'process.env.VERSION': JSON.stringify(
-              dependencies['@geostreams/core']
+                dependencies['@geostreams/core']
             ),
             'process.env.CONTEXT': JSON.stringify(process.env.CONTEXT)
         }),


### PR DESCRIPTION
Changes were done to webpack to optimize loading and lazy loading geojson and json files (only those pertaining to the trendsdata), we have drastically reduced the bundle size.

Previous bundle:
![image](https://github.com/geostreams/gltg/assets/16596733/75d9fd5d-e62b-4a56-bb89-9301502f75b3)
Total Size - 17.15 MB


Current bundle:
![image](https://github.com/geostreams/gltg/assets/16596733/e25d689f-bd5c-44c8-a7e6-777854e1e286)
Total size - 11.56 MB