### PR TITLE
Fixed the icon bug

### DIFF
--- a/src/containers/Summary/index.jsx
+++ b/src/containers/Summary/index.jsx
@@ -378,7 +378,7 @@ const Summary = () => {
 		// This is the interaction to set style for the selected station
 		if (oldSelectedStation !== selectedStation) {
 			if (oldSelectedStation) {
-				oldSelectedStation.setStyle(renderIcon);
+				oldSelectedStation.setStyle(null); // Remove custom style to fall back to layer style
 			}
 		}
 


### PR DESCRIPTION
Previously after selection, the station no longer switches. This is cos the custom styling we applied overwrote the original layer styling. We just needed to remove the custom styling by setting it to null